### PR TITLE
Add option to pass extra args to reward fn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,5 @@ core
 *jianh*
 *test_scripts*
 */checkpoint/*
+
+.*swp

--- a/openrlhf/cli/train_ppo_ray.py
+++ b/openrlhf/cli/train_ppo_ray.py
@@ -5,6 +5,7 @@ from typing import List
 import ray
 import torch
 from ray.util.placement_group import placement_group
+from pprint import pprint
 
 from openrlhf.trainer.ray import (
     ActorModelRayActor,
@@ -369,7 +370,14 @@ if __name__ == "__main__":
     # performance tuning
     parser.add_argument("--perf", action="store_true", default=False)
 
+    parser.add_argument("--extra_args", type=str, default=None)
+
     args = parser.parse_args()
+
+    args.extra_args = json.loads(args.extra_args) if args.extra_args is not None else {}
+
+    print('Extra Args:')
+    pprint(args.extra_args)
 
     if args.advantage_estimator not in ["gae"]:
         args.critic_pretrain = None

--- a/openrlhf/cli/train_ppo_ray.py
+++ b/openrlhf/cli/train_ppo_ray.py
@@ -371,7 +371,7 @@ if __name__ == "__main__":
     # performance tuning
     parser.add_argument("--perf", action="store_true", default=False)
 
-    parser.add_argument("--extra_args", type=str, default=None)
+    parser.add_argument("--extra_args", type=str, default="{}")
 
     args = parser.parse_args()
 

--- a/openrlhf/cli/train_ppo_ray.py
+++ b/openrlhf/cli/train_ppo_ray.py
@@ -371,14 +371,14 @@ if __name__ == "__main__":
     # performance tuning
     parser.add_argument("--perf", action="store_true", default=False)
 
-    parser.add_argument("--extra_args", type=str, default="{}")
+    parser.add_argument("--extra_rm_args", type=str, default="{}")
 
     args = parser.parse_args()
 
-    args.extra_args = json.loads(args.extra_args)
+    args.extra_rm_args = json.loads(args.extra_rm_args)
 
-    print('Extra Args:')
-    pprint(args.extra_args)
+    print('Extra RM Args:')
+    pprint(args.extra_rm_args)
 
     if args.advantage_estimator not in ["gae"]:
         args.critic_pretrain = None

--- a/openrlhf/cli/train_ppo_ray.py
+++ b/openrlhf/cli/train_ppo_ray.py
@@ -6,6 +6,7 @@ import ray
 import torch
 from ray.util.placement_group import placement_group
 from pprint import pprint
+import json
 
 from openrlhf.trainer.ray import (
     ActorModelRayActor,

--- a/openrlhf/cli/train_ppo_ray.py
+++ b/openrlhf/cli/train_ppo_ray.py
@@ -375,7 +375,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    args.extra_args = json.loads(args.extra_args) if args.extra_args is not None else {}
+    args.extra_args = json.loads(args.extra_args)
 
     print('Extra Args:')
     pprint(args.extra_args)

--- a/openrlhf/datasets/prompts_dataset.py
+++ b/openrlhf/datasets/prompts_dataset.py
@@ -16,7 +16,6 @@ def preprocess_data(data, input_template=None, input_key="input", apply_chat_tem
             prompt = input_template.format(prompt)
     return prompt
 
-
 class PromptDataset(Dataset):
     """
     Dataset for PPO model
@@ -47,13 +46,11 @@ class PromptDataset(Dataset):
             apply_chat_template = self.tokenizer.apply_chat_template
 
         self.prompts = []
+        self.prompt_metadata = []
         for data in tqdm(dataset, desc="Preprocessing data", disable=not self.strategy.is_rank_0()):
             prompt = preprocess_data(data, input_template, input_key, apply_chat_template)
-            prompt_dict = {"_prompt": prompt}
-            prompt_dict.update(data)
-            # we are encoding back to string since DeepSeek handles dict data
-            # natively in some strange way which we want to avoid
-            prompt = json.dumps(prompt_dict)
+            data.pop(input_key)
+            self.prompt_metadata.append(data)
             self.prompts.append(prompt)
 
     def __len__(self):
@@ -61,4 +58,4 @@ class PromptDataset(Dataset):
         return length
 
     def __getitem__(self, idx):
-        return self.prompts[idx]
+        return self.prompts[idx], self.prompt_metadata[idx]

--- a/openrlhf/datasets/prompts_dataset.py
+++ b/openrlhf/datasets/prompts_dataset.py
@@ -47,9 +47,10 @@ class PromptDataset(Dataset):
 
         self.prompts = []
         self.prompt_metadata = []
-        for data in tqdm(dataset, desc="Preprocessing data", disable=not self.strategy.is_rank_0()):
+        for i, data in tqdm(enumerate(dataset), desc="Preprocessing data", disable=not self.strategy.is_rank_0()):
             prompt = preprocess_data(data, input_template, input_key, apply_chat_template)
             data.pop(input_key)
+            data['_idx'] = i
             self.prompt_metadata.append(data)
             self.prompts.append(prompt)
 

--- a/openrlhf/trainer/ppo_trainer.py
+++ b/openrlhf/trainer/ppo_trainer.py
@@ -231,7 +231,7 @@ class PPOTrainer(ABC):
 
             for rand_prompts, input_dict in self.prompts_dataloader:
                 for i, experience in enumerate(
-                    self.experience_maker.make_experience_list(args, (rand_prompts, input_dict), **self.generate_kwargs)
+                    self.experience_maker.make_experience_list(args.extra_rm_args, (rand_prompts, input_dict), **self.generate_kwargs)
                 ):
                     if i == 0:
                         output = self.tokenizer.batch_decode(

--- a/openrlhf/trainer/ppo_trainer.py
+++ b/openrlhf/trainer/ppo_trainer.py
@@ -229,9 +229,9 @@ class PPOTrainer(ABC):
                 disable=not self.strategy.is_rank_0(),
             )
 
-            for rand_prompts in self.prompts_dataloader:
+            for rand_prompts, input_dict in self.prompts_dataloader:
                 for i, experience in enumerate(
-                    self.experience_maker.make_experience_list(rand_prompts, **self.generate_kwargs)
+                    self.experience_maker.make_experience_list(args, (rand_prompts, input_dict), **self.generate_kwargs)
                 ):
                     if i == 0:
                         output = self.tokenizer.batch_decode(

--- a/openrlhf/trainer/ppo_utils/experience_maker.py
+++ b/openrlhf/trainer/ppo_utils/experience_maker.py
@@ -589,7 +589,7 @@ class RemoteExperienceMaker(NaiveExperienceMaker):
                 queries = self.tokenizer.batch_decode(sequences_list, skip_special_tokens=False)
 
             if self.custom_reward_func:
-                r = self.custom_reward_func.remote(queries, samples.prompts, samples.prompt_metadata, **(args.extra_args))
+                r = self.custom_reward_func.remote(queries, samples.prompts, samples.prompt_metadata, **args.extra_args)
                 r_refs.append(r)
             else:
                 for rm in self.remote_rm_url:

--- a/openrlhf/trainer/ppo_utils/experience_maker.py
+++ b/openrlhf/trainer/ppo_utils/experience_maker.py
@@ -156,6 +156,7 @@ class NaiveExperienceMaker(ABC):
         if remote_rm_url and remote_rm_url[0].endswith(".py"):
             print(f"Loading custom `reward_func(queries, prompts)` from {remote_rm_url[0]}")
             import importlib.util
+            import inspect
 
             spec = importlib.util.spec_from_file_location("reward_func", remote_rm_url[0])
             reward_module = importlib.util.module_from_spec(spec)

--- a/openrlhf/trainer/ppo_utils/experience_maker.py
+++ b/openrlhf/trainer/ppo_utils/experience_maker.py
@@ -3,7 +3,7 @@ import time
 from abc import ABC
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union, Dict
 
 import ray
 import torch
@@ -183,7 +183,7 @@ class NaiveExperienceMaker(ABC):
         return {k: v.to(device) for k, v in batch.items()}
 
     @torch.no_grad()
-    def make_experience_list(self, all_prompts: Union[str, List[str]], **generate_kwargs) -> List[Experience]:
+    def make_experience_list(self, args, all_prompts: Union[Dict, List[Dict]], **generate_kwargs) -> List[Experience]:
         """
         Make a list of experience with the micro_rollout_batch_size.
 
@@ -202,7 +202,7 @@ class NaiveExperienceMaker(ABC):
             desc="make_experience",
             disable=not self.strategy.is_rank_0(),
         ):
-            experiences.append(self.make_experience(samples).to_device("cpu"))
+            experiences.append(self.make_experience(args, samples).to_device("cpu"))
 
         experiences, rewards = self.process_experiences(experiences)
 
@@ -257,6 +257,7 @@ class NaiveExperienceMaker(ABC):
         """
         Generate samples and return in batches.
         """
+        all_prompts, all_prompt_metadata = all_prompts
         assert not getattr(self, "packing_samples", False)
         args = self.strategy.args
         self.actor.eval()
@@ -264,13 +265,9 @@ class NaiveExperienceMaker(ABC):
         all_prompts = sum([[prompt] * args.n_samples_per_prompt for prompt in all_prompts], [])
         samples_list = []
         for i in range(0, len(all_prompts), args.micro_rollout_batch_size):
+            prompt_metadata = all_prompt_metadata[i : i + args.micro_rollout_batch_size]
             prompts = all_prompts[i : i + args.micro_rollout_batch_size]
-            decoded_prompt_dicts = [json.loads(prompt) for prompt in prompts]
-            prompt_strings = [prompt_dict["_prompt"] for prompt_dict in decoded_prompt_dicts]
-            prompt_metadata = [prompt_dict for prompt_dict in decoded_prompt_dicts]
-            for prompt_dict in prompt_metadata:
-                prompt_dict.pop("_prompt")
-            inputs = self.tokenize_fn(prompt_strings, self.prompt_max_len, device="cuda")
+            inputs = self.tokenize_fn(prompts, self.prompt_max_len, device="cuda")
             sequences, attention_mask, action_mask = self.actor.generate(**inputs, **generate_kwargs)
             samples = Samples(
                 sequences=sequences,
@@ -287,7 +284,7 @@ class NaiveExperienceMaker(ABC):
         return samples_list
 
     @torch.no_grad()
-    def make_experience(self, samples: Samples) -> Experience:
+    def make_experience(self, args, samples: Samples) -> Experience:
         """
         Turn samples into experience by calculating logprobs, values, rewards, and kl divergence.
         """
@@ -322,7 +319,7 @@ class NaiveExperienceMaker(ABC):
             # remote RM
             queries = self.tokenizer.batch_decode(sequences.cpu(), skip_special_tokens=False)
             if self.custom_reward_func:
-                r = self.custom_reward_func(queries, samples.prompts, samples.prompt_metadata).to(device=action_log_probs.device)
+                r = self.custom_reward_func(args, queries, samples.prompts, samples.prompt_metadata).to(device=action_log_probs.device)
             else:
                 r = remote_rm_fn(self.remote_rm_url, queries=queries, prompts=samples.prompts).to(
                     device=action_log_probs.device
@@ -499,14 +496,14 @@ class RemoteExperienceMaker(NaiveExperienceMaker):
             self.custom_reward_func = ray.remote(self.custom_reward_func)
 
     @torch.no_grad()
-    def make_experience_list(self, all_prompts: Union[str, List[str]], **generate_kwargs) -> List[Experience]:
+    def make_experience_list(self, args, all_prompts: Union[Dict, List[Dict]], **generate_kwargs) -> List[Experience]:
         if self.strategy.args.perf:
             self.perf_stats = {
                 "generate_time": 0,
                 "actor_value_rm_time": 0,
                 "wait_time": 0,
             }
-        experiences = super().make_experience_list(all_prompts, **generate_kwargs)
+        experiences = super().make_experience_list(args, all_prompts, **generate_kwargs)
         if self.critic is not None:
             for experience in experiences:
                 # send experience to critic
@@ -516,7 +513,7 @@ class RemoteExperienceMaker(NaiveExperienceMaker):
         return experiences
 
     @torch.no_grad()
-    def generate_samples(self, all_prompts: List[str], **generate_kwargs) -> List[Samples]:
+    def generate_samples(self, all_prompts: List[Dict], **generate_kwargs) -> List[Samples]:
         """
         Generate samples and return in batches.
 
@@ -529,7 +526,7 @@ class RemoteExperienceMaker(NaiveExperienceMaker):
         return self._generate_vllm(all_prompts, **generate_kwargs)
 
     @torch.no_grad()
-    def make_experience(self, samples: Samples) -> Experience:
+    def make_experience(self, args, samples: Samples) -> Experience:
         """
         Turn samples into experience by calculating logprobs, values, rewards, and kl divergence.
         """
@@ -591,7 +588,7 @@ class RemoteExperienceMaker(NaiveExperienceMaker):
                 queries = self.tokenizer.batch_decode(sequences_list, skip_special_tokens=False)
 
             if self.custom_reward_func:
-                r = self.custom_reward_func.remote(queries, samples.prompts, samples.prompt_metadata)
+                r = self.custom_reward_func.remote(args, queries, samples.prompts, samples.prompt_metadata)
                 r_refs.append(r)
             else:
                 for rm in self.remote_rm_url:
@@ -678,9 +675,10 @@ class RemoteExperienceMaker(NaiveExperienceMaker):
         self.actor.train()  # reset model state
         return experience
 
-    def _generate_vllm(self, all_prompts: List[str], **kwargs) -> List[Samples]:
+    def _generate_vllm(self, all_prompts: List[Dict], **kwargs) -> List[Samples]:
         from vllm import SamplingParams
 
+        all_prompts, all_prompt_metadata = all_prompts
         # round-robin load balance
         rank = torch.distributed.get_rank()
         world_size = torch.distributed.get_world_size()
@@ -705,15 +703,7 @@ class RemoteExperienceMaker(NaiveExperienceMaker):
 
         # Expand prompt list based on the number of samples per prompt
         all_prompts = sum([[prompt] * args.n_samples_per_prompt for prompt in all_prompts], [])
-
-        decoded_prompt_dicts = [json.loads(prompt) for prompt in all_prompts]
-        prompt_strings = [prompt_dict["_prompt"] for prompt_dict in decoded_prompt_dicts]
-        prompt_metadata = [prompt_dict for prompt_dict in decoded_prompt_dicts]
-        for prompt_dict in prompt_metadata:
-            prompt_dict.pop("_prompt")
-
-
-        all_prompt_token_ids = self.tokenize_fn(prompt_strings, self.prompt_max_len, padding=False)["input_ids"]
+        all_prompt_token_ids = self.tokenize_fn(all_prompts, self.prompt_max_len, padding=False)["input_ids"]
 
         # Distribute requests to engines and collect responses to outputs
         all_output_refs = []
@@ -731,8 +721,8 @@ class RemoteExperienceMaker(NaiveExperienceMaker):
         samples_list = []
         for i in range(0, len(all_outputs), args.micro_rollout_batch_size):
             outputs = all_outputs[i : i + self.strategy.args.micro_rollout_batch_size]
-            prompts = prompt_strings[i : i + self.strategy.args.micro_rollout_batch_size]
-            cur_metadata = prompt_metadata[i : i + self.strategy.args.micro_rollout_batch_size]
+            prompts = all_prompts[i : i + self.strategy.args.micro_rollout_batch_size]
+            cur_metadata = all_prompt_metadata[i : i + self.strategy.args.micro_rollout_batch_size]
             if not self.packing_samples:
                 # NOTE: concat all outputs to following format:
                 #

--- a/openrlhf/trainer/ppo_utils/experience_maker.py
+++ b/openrlhf/trainer/ppo_utils/experience_maker.py
@@ -319,7 +319,7 @@ class NaiveExperienceMaker(ABC):
             # remote RM
             queries = self.tokenizer.batch_decode(sequences.cpu(), skip_special_tokens=False)
             if self.custom_reward_func:
-                r = self.custom_reward_func(args, queries, samples.prompts, samples.prompt_metadata).to(device=action_log_probs.device)
+                r = self.custom_reward_func(queries, samples.prompts, samples.prompt_metadata, **(args.extra_args)).to(device=action_log_probs.device)
             else:
                 r = remote_rm_fn(self.remote_rm_url, queries=queries, prompts=samples.prompts).to(
                     device=action_log_probs.device
@@ -588,7 +588,7 @@ class RemoteExperienceMaker(NaiveExperienceMaker):
                 queries = self.tokenizer.batch_decode(sequences_list, skip_special_tokens=False)
 
             if self.custom_reward_func:
-                r = self.custom_reward_func.remote(args, queries, samples.prompts, samples.prompt_metadata)
+                r = self.custom_reward_func.remote(queries, samples.prompts, samples.prompt_metadata, **(args.extra_args))
                 r_refs.append(r)
             else:
                 for rm in self.remote_rm_url:

--- a/openrlhf/trainer/ray/ppo_actor.py
+++ b/openrlhf/trainer/ray/ppo_actor.py
@@ -345,8 +345,13 @@ class ActorModelRayActor(BasePPORole):
         self.prompts_dataset = PromptDataset(
             prompts_data, self.tokenizer, strategy, input_template=args.input_template
         )
+
+        def custom_collate_fn(batch):
+            prompts, data = zip(*batch)
+            return list(prompts), list(data)
+
         self.prompts_dataloader = strategy.setup_dataloader(
-            self.prompts_dataset, args.rollout_batch_size // strategy.world_size, True, True
+            self.prompts_dataset, args.rollout_batch_size // strategy.world_size, True, True, collate_fn=custom_collate_fn,
         )
 
         if args.pretrain_data:


### PR DESCRIPTION

Use example "{\"timeout\": 2.0}" to pass in extra arguments

Also changed dataloader so we don't have to json.loads all the time during training

- **added vim swp file ignore**
- **removed constant json unpacking**
- **debugging**
- **fixing extra args import**
- **fixed extra args**
