### PR TITLE
Correctly save final DS checkpoint after ending training

### DIFF
--- a/openrlhf/cli/train_sft.py
+++ b/openrlhf/cli/train_sft.py
@@ -156,7 +156,6 @@ def train(args):
         max_time_per_run=args.max_time_per_run,
     )
 
-
     trainer.fit(args, consumed_samples, num_update_steps_per_epoch)
 
     # save model checkpoint after fitting on only rank0

--- a/openrlhf/cli/train_sft.py
+++ b/openrlhf/cli/train_sft.py
@@ -168,7 +168,7 @@ def train(args):
     args.eval_steps = global_step if args.eval_steps > 0 else args.eval_steps
     args.save_steps = global_step if args.save_steps > 0 else args.save_steps
 
-    self.save_logs_and_checkpoints(args, global_step, None, {}, client_states)
+    trainer.save_logs_and_checkpoints(args, global_step, None, {}, client_states)
 
     # save model checkpoint after fitting on only rank0
     strategy.save_model(model, tokenizer, args.save_path)

--- a/openrlhf/cli/train_sft.py
+++ b/openrlhf/cli/train_sft.py
@@ -159,17 +159,6 @@ def train(args):
 
     trainer.fit(args, consumed_samples, num_update_steps_per_epoch)
 
-    # Save deepspeed checkpoint
-    global_step = max_steps
-    client_states = {"consumed_samples": global_step * args.train_batch_size}
-    # We will force logging, evaluation and checkpointing to occur immediately
-    # by forcing the value of these step counter equal to global_step
-    args.logging_steps = global_step if args.logging_steps > 0 else args.logging_steps
-    args.eval_steps = global_step if args.eval_steps > 0 else args.eval_steps
-    args.save_steps = global_step if args.save_steps > 0 else args.save_steps
-
-    trainer.save_logs_and_checkpoints(args, global_step, None, {}, client_states)
-
     # save model checkpoint after fitting on only rank0
     strategy.save_model(model, tokenizer, args.save_path)
 

--- a/openrlhf/trainer/sft_trainer.py
+++ b/openrlhf/trainer/sft_trainer.py
@@ -221,6 +221,17 @@ class SFTTrainer(ABC):
 
             epoch_bar.update()
 
+        # Save deepspeed checkpoint
+        global_step = max_steps
+        client_states = {"consumed_samples": global_step * args.train_batch_size}
+        # We will force logging, evaluation and checkpointing to occur immediately
+        # by forcing the value of these step counter equal to global_step
+        args.logging_steps = global_step if args.logging_steps > 0 else args.logging_steps
+        args.eval_steps = global_step if args.eval_steps > 0 else args.eval_steps
+        args.save_steps = global_step if args.save_steps > 0 else args.save_steps
+
+        self.save_logs_and_checkpoints(args, global_step, step_bar, {}, client_states)
+
         if self._wandb is not None and self.strategy.is_rank_0():
             self._wandb.finish()
         if self._tensorboard is not None and self.strategy.is_rank_0():

--- a/openrlhf/trainer/sft_trainer.py
+++ b/openrlhf/trainer/sft_trainer.py
@@ -222,6 +222,11 @@ class SFTTrainer(ABC):
             epoch_bar.update()
 
         # Save deepspeed checkpoint
+        # If we have already finished training, then we decrement the step counter that was auto incremented
+        # before the start of epoch
+        if start_epoch == self.epochs:
+            step -= 1
+
         global_step = step // self.strategy.accumulated_gradient
         client_states = {"consumed_samples": global_step * args.train_batch_size}
         # We will force logging, evaluation and checkpointing to occur immediately

--- a/openrlhf/trainer/sft_trainer.py
+++ b/openrlhf/trainer/sft_trainer.py
@@ -222,7 +222,7 @@ class SFTTrainer(ABC):
             epoch_bar.update()
 
         # Save deepspeed checkpoint
-        global_step = max_steps
+        global_step = step // self.strategy.accumulated_gradient
         client_states = {"consumed_samples": global_step * args.train_batch_size}
         # We will force logging, evaluation and checkpointing to occur immediately
         # by forcing the value of these step counter equal to global_step
@@ -230,7 +230,7 @@ class SFTTrainer(ABC):
         args.eval_steps = global_step if args.eval_steps > 0 else args.eval_steps
         args.save_steps = global_step if args.save_steps > 0 else args.save_steps
 
-        self.save_logs_and_checkpoints(args, global_step, step_bar, {}, client_states)
+        self.save_logs_and_checkpoints(args, global_step, None, {}, client_states)
 
         if self._wandb is not None and self.strategy.is_rank_0():
             self._wandb.finish()

--- a/openrlhf/utils/utils.py
+++ b/openrlhf/utils/utils.py
@@ -91,7 +91,7 @@ def blending_datasets(
                 eval_data = data[eval_split].select(range(min(max_count, len(data[eval_split]))))
             # train will contains eval? TODO
             else:
-                eval_data = train_data.select(range(min(max_count, int(len(train_data) * 0.03))))
+                eval_data = train_data.select(range(min(max_count, max(1, int(len(train_data) * 0.03)))))
             eval_data_list.append(eval_data)
 
     # merge datasets


### PR DESCRIPTION
# Changelog
- Save final deepspeed checkpoint so that upon resumption, the consumed_samples indicates that checkpoint has finished training and skips epoch
- Fix eval calculation when num samples is small enough such that 0.03 * train_size == 0
