### PR TITLE
Eval and ckpt improvements

### DIFF
--- a/openrlhf/cli/train_ppo_ray.py
+++ b/openrlhf/cli/train_ppo_ray.py
@@ -33,11 +33,6 @@ def _validate_args(args):
 
     assert args.zero_stage != 3 or args.vllm_num_engines > 0, f"ZeRO-3 is only supported when vLLM enabled"
 
-    if args.vllm_num_engines > 0:
-        assert (
-            actor_world_size % args.vllm_num_engines == 0
-        ), f"actor_world_size must be divisible by vllm_num_engines, got {actor_world_size} and {args.vllm_num_engines}"
-
     if args.critic_pretrain:
         critic_world_size = args.critic_num_nodes * args.critic_num_gpus_per_node
         assert (

--- a/openrlhf/trainer/ppo_trainer.py
+++ b/openrlhf/trainer/ppo_trainer.py
@@ -501,10 +501,14 @@ class PPOTrainer(ABC):
                 disable=not self.strategy.is_rank_0(),
             )
 
+            eval_generate_kwargs = self.generate_kwargs.copy()
+            # Set greedy sampling for eval
+            eval_generate_kwargs['temperature'] = 0
+
             logs_dict = {}
             for prompts, input_dict in dataloader:
                 for i, experience in enumerate(
-                    self.experience_maker.make_experience_list(extra_rm_args, (prompts, input_dict), **self.generate_kwargs)
+                    self.experience_maker.make_experience_list(extra_rm_args, (prompts, input_dict), **eval_generate_kwargs)
                 ):
                     eval_buffer['reward'].extend(experience.info['reward'])
                     pbar.update()

--- a/openrlhf/trainer/ray/ppo_actor.py
+++ b/openrlhf/trainer/ray/ppo_actor.py
@@ -2,6 +2,7 @@ import itertools
 import math
 import os
 import socket
+import subprocess
 from typing import Callable, Dict, List
 
 import deepspeed
@@ -20,6 +21,13 @@ from openrlhf.utils.distributed_util import init_process_group
 from openrlhf.utils.max_time_manager import MaxTimeManager
 
 from .launcher import BasePPORole
+
+def global_ray_shutdown():
+    try:
+        subprocess.run(["ray", "stop"], check=True)
+        print("Ray processes have been stopped successfully.")
+    except subprocess.CalledProcessError:
+        print("An error occurred while trying to stop Ray processes.")
 
 
 class ActorPPOTrainer(PPOTrainer):
@@ -138,7 +146,7 @@ class ActorPPOTrainer(PPOTrainer):
             # Call super() to save the logs and checkpoints
             super().save_logs_and_checkpoints(args, global_step, step_bar, logs_dict, client_states)
             # Exit the program early
-            raise Exception(f"Max time has been reached. Signalling to save a checkpoint.")
+            global_ray_shutdown()
         else:
             return super().save_logs_and_checkpoints(args, global_step, step_bar, logs_dict, client_states)
 


### PR DESCRIPTION
## Changelog

* Use greedy sampling for evaluation
* Exit on timeout with graceful shutdown instead of error. This improves ability to resume jobs with slurm dependencies.
* Remove vllm_num_engines restricition based on actor world size. This check did not appear to have any effect.